### PR TITLE
detecting received error not being handled

### DIFF
--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -33,6 +33,10 @@ func main() {
 		panic(err)
 	}
 
+	if _, err := f(); err == nil { // OK
+		panic(err)
+	}
+
 	if a, _ := f(); a != 0 { // want "receiving error with _"
 		panic(err)
 	}

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -29,6 +29,14 @@ func main() {
 		panic(err)
 	}
 
+	if _, err := f(); err != nil { // OK
+		panic(err)
+	}
+
+	_, err = f() // want "error received but not handled"
+
+	b := errors.New("foo") // want "error received but not handled"
+
 	_, _ = f() // want "receiving error with _"
 
 	a, _ := f() // want "receiving error with _"
@@ -55,5 +63,5 @@ func main() {
 	if !ok {
 	}
 
-	print(a)
+	print(a, b)
 }

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -33,6 +33,10 @@ func main() {
 		panic(err)
 	}
 
+	if a, _ := f(); a != 0 { // want "receiving error with _"
+		panic(err)
+	}
+
 	_, err = f() // want "error received but not handled"
 
 	b := errors.New("foo") // want "error received but not handled"


### PR DESCRIPTION
## issue
https://github.com/Khdbble/errorhandle/issues/2

## 内容
`error`型の値を関数呼び出しから受け取った際に、条件分岐による処理を行っているかを判別。
```go
func f() error {}

// NG case
err := f() // error received but not handled

// OK case
err := f() // OK
if err != nil {
}

// OK case
if err := f(); err != nil { // OK
}

```